### PR TITLE
feat: add messaging functionality with Slack support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+poetry install
+
+# Run tests (requires DEF_API_KEY environment variable)
+DEF_API_KEY=your_api_key poetry run pytest
+
+# Run specific test
+DEF_API_KEY=your_api_key poetry run pytest tests/test_store.py::test_kv_store_operations
+
+# Code formatting
+poetry run black .
+
+# Linting
+poetry run flake8
+
+# Type checking
+poetry run mypy definite_sdk/
+```
+
+## Architecture Overview
+
+This SDK provides Python clients for Definite's cloud storage API (https://api.definite.app). The codebase follows a simple client-factory pattern:
+
+1. **DefiniteClient** (client.py): Main entry point that creates store instances
+2. **Store Implementations**:
+   - **DefiniteKVStore** (store.py): Dictionary-like persistent key-value storage with version control
+   - **DefiniteSecretStore** (secret.py): Direct API for managing application secrets
+   - **DefiniteIntegrationStore** (integration.py): Read-only access to integration configurations
+
+Key architectural decisions:
+- KV Store uses optimistic locking with version IDs to prevent conflicts
+- KV Store requires explicit `commit()` to persist changes (transactional model)
+- Secret and Integration stores persist changes immediately
+- All API calls use Bearer token authentication
+- No caching - each operation makes direct API calls
+
+## Known Issues
+
+- integration.py incorrectly uses `SECRET_STORE_ENDPOINT` instead of a proper integration endpoint constant

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Definite SDK
 
-A Python client for interacting with the Definite API, providing a convenient interface for key-value store operations, SQL query execution, secrets management, and DLT (Data Load Tool) integration with state persistence.
+A Python client for interacting with the Definite API, providing a convenient interface for key-value store operations, SQL query execution, secrets management, messaging capabilities, and DLT (Data Load Tool) integration with state persistence.
 
 ## Installation
 
@@ -36,6 +36,7 @@ client = DefiniteClient("YOUR_API_KEY")
 - **Cube Query Execution**: Execute Cube queries for advanced analytics and data modeling
 - **Secret Management**: Secure storage and retrieval of application secrets
 - **Integration Store**: Read-only access to integration configurations
+- **Messaging**: Send messages through various channels (Slack, and more coming soon)
 - **dlt Integration**: Run dlt pipelines with automatic state persistence to Definite
 - **DuckDB Support**: Automatic discovery and connection to team's DuckDB integrations
 
@@ -144,6 +145,49 @@ integrations = list(integration_store.list_integrations())
 
 # Get a specific integration
 integration = integration_store.get_integration("my_integration")
+```
+
+### 💬 Messaging
+
+Send messages through various channels using the messaging client.
+
+```python
+# Initialize the message client
+message_client = client.get_message_client()
+# Or use the alias method
+message_client = client.message_client()
+
+# Send a Slack message using the unified interface
+result = message_client.send_message(
+    channel="slack",
+    integration_id="your_slack_integration_id",
+    to="C0920MVPWFN",  # Slack channel ID
+    content="Hello from Definite SDK! 👋"
+)
+
+# Send a Slack message with blocks and threading
+result = message_client.send_message(
+    channel="slack",
+    integration_id="your_slack_integration_id",
+    to="C0920MVPWFN",
+    content="Fallback text",
+    blocks=[{
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*Important Update*"}
+    }],
+    thread_ts="1234567890.123456"  # Reply in thread
+)
+
+# Or use the convenience method for Slack
+result = message_client.send_slack_message(
+    integration_id="your_slack_integration_id",
+    channel_id="C0920MVPWFN",
+    text="Quick message using the convenience method!",
+    blocks=[{
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "Message with *rich* _formatting_"}
+    }]
+)
 ```
 
 ### dlt Integration

--- a/definite_sdk/__init__.py
+++ b/definite_sdk/__init__.py
@@ -6,6 +6,7 @@ A Python library for interacting with the Definite API and tools.
 
 from definite_sdk.client import DefiniteClient
 from definite_sdk.integration import DefiniteIntegrationStore
+from definite_sdk.message import DefiniteMessageClient
 from definite_sdk.secret import DefiniteSecretStore
 from definite_sdk.sql import DefiniteSqlClient
 from definite_sdk.store import DefiniteKVStore
@@ -14,6 +15,7 @@ __version__ = "0.1.8"
 __all__ = [
     "DefiniteClient",
     "DefiniteIntegrationStore",
+    "DefiniteMessageClient",
     "DefiniteSecretStore",
     "DefiniteSqlClient",
     "DefiniteKVStore",

--- a/definite_sdk/client.py
+++ b/definite_sdk/client.py
@@ -2,6 +2,7 @@ import os
 from typing import Optional
 
 from definite_sdk.integration import DefiniteIntegrationStore
+from definite_sdk.message import DefiniteMessageClient
 from definite_sdk.secret import DefiniteSecretStore
 from definite_sdk.sql import DefiniteSqlClient
 from definite_sdk.store import DefiniteKVStore
@@ -77,3 +78,15 @@ class DefiniteClient:
     def integration_store(self) -> DefiniteIntegrationStore:
         """Alias for get_integration_store."""
         return self.get_integration_store()
+
+    def get_message_client(self) -> DefiniteMessageClient:
+        """Initializes the message client for sending messages via various channels.
+
+        See DefiniteMessageClient for more how to send messages.
+        """
+
+        return DefiniteMessageClient(self.api_key, self.api_url)
+
+    def message_client(self) -> DefiniteMessageClient:
+        """Alias for get_message_client."""
+        return self.get_message_client()

--- a/definite_sdk/message.py
+++ b/definite_sdk/message.py
@@ -1,0 +1,199 @@
+from typing import Any, Dict, List, Optional
+
+import requests
+
+MESSAGE_ENDPOINT = "/v3"
+
+
+class DefiniteMessageClient:
+    """
+    A message client for sending messages via various channels through the Definite API.
+
+    Initialization:
+    >>> client = DefiniteClient("MY_API_KEY")
+    >>> message_client = client.get_message_client()
+
+    Sending messages:
+    >>> # Send a Slack message
+    >>> result = message_client.send_message(
+    ...     channel="slack",
+    ...     integration_id="slack_integration_id",
+    ...     to="C0920MVPWFN",  # channel_id
+    ...     content="Hello from Definite SDK!"
+    ... )
+    
+    >>> # Send a Slack message with blocks and thread
+    >>> result = message_client.send_message(
+    ...     channel="slack",
+    ...     integration_id="slack_integration_id",
+    ...     to="C0920MVPWFN",
+    ...     content="Hello!",
+    ...     blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": "Hello!"}}],
+    ...     thread_ts="1234567890.123456"
+    ... )
+    """
+
+    def __init__(self, api_key: str, api_url: str):
+        """
+        Initializes the DefiniteMessageClient.
+
+        Args:
+            api_key (str): The API key for authorization.
+            api_url (str): The base URL for the Definite API.
+        """
+        self._api_key = api_key
+        self._message_url = api_url + MESSAGE_ENDPOINT
+
+    def send_message(
+        self,
+        channel: str,
+        integration_id: str,
+        to: str,
+        content: str,
+        subject: Optional[str] = None,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+        thread_ts: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
+        """
+        Sends a message through the specified channel.
+
+        Args:
+            channel (str): The messaging channel to use (e.g., "slack", "email").
+            integration_id (str): The ID of the integration to use.
+            to (str): The recipient identifier (channel_id for Slack, email address for email).
+            content (str): The message content (text for Slack, body for email).
+            subject (Optional[str]): Subject line (used for email).
+            blocks (Optional[List[Dict[str, Any]]]): Slack Block Kit blocks for formatting.
+            thread_ts (Optional[str]): Slack thread timestamp to reply to.
+            **kwargs: Additional channel-specific parameters.
+
+        Returns:
+            Dict[str, Any]: The response from the API.
+
+        Raises:
+            requests.HTTPError: If the API request fails.
+            ValueError: If the channel is not supported.
+
+        Example:
+            >>> # Slack message
+            >>> result = message_client.send_message(
+            ...     channel="slack",
+            ...     integration_id="slack_123",
+            ...     to="C0920MVPWFN",
+            ...     content="Hello team!"
+            ... )
+            
+            >>> # Slack message with blocks
+            >>> result = message_client.send_message(
+            ...     channel="slack",
+            ...     integration_id="slack_123",
+            ...     to="C0920MVPWFN",
+            ...     content="Fallback text",
+            ...     blocks=[{
+            ...         "type": "section",
+            ...         "text": {"type": "mrkdwn", "text": "*Important Update*"}
+            ...     }]
+            ... )
+        """
+        channel_lower = channel.lower()
+        
+        if channel_lower == "slack":
+            return self._send_slack_message(
+                integration_id=integration_id,
+                channel_id=to,
+                text=content,
+                blocks=blocks,
+                thread_ts=thread_ts,
+                **kwargs
+            )
+        else:
+            raise ValueError(f"Unsupported channel: {channel}")
+
+    def _send_slack_message(
+        self,
+        integration_id: str,
+        channel_id: str,
+        text: str,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+        thread_ts: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
+        """
+        Internal method to send a Slack message.
+
+        Args:
+            integration_id (str): The Slack integration ID.
+            channel_id (str): The Slack channel ID.
+            text (str): The message text.
+            blocks (Optional[List[Dict[str, Any]]]): Slack blocks for formatting.
+            thread_ts (Optional[str]): Thread timestamp for replies.
+            **kwargs: Additional Slack-specific parameters.
+
+        Returns:
+            Dict[str, Any]: The API response.
+        """
+        url = f"{self._message_url}/slack/message"
+        
+        payload = {
+            "integration_id": integration_id,
+            "channel_id": channel_id,
+            "text": text
+        }
+        
+        if blocks:
+            payload["blocks"] = blocks
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+            
+        # Add any additional kwargs to the payload
+        payload.update(kwargs)
+
+        response = requests.post(
+            url,
+            json=payload,
+            headers={"Authorization": "Bearer " + self._api_key},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def send_slack_message(
+        self,
+        integration_id: str,
+        channel_id: str,
+        text: str,
+        blocks: Optional[List[Dict[str, Any]]] = None,
+        thread_ts: Optional[str] = None,
+        **kwargs: Any
+    ) -> Dict[str, Any]:
+        """
+        Convenience method to send a Slack message directly.
+
+        Args:
+            integration_id (str): The Slack integration ID.
+            channel_id (str): The Slack channel ID.
+            text (str): The message text.
+            blocks (Optional[List[Dict[str, Any]]]): Slack blocks for formatting.
+            thread_ts (Optional[str]): Thread timestamp for replies.
+            **kwargs: Additional Slack-specific parameters.
+
+        Returns:
+            Dict[str, Any]: The API response.
+
+        Example:
+            >>> result = message_client.send_slack_message(
+            ...     integration_id="slack_123",
+            ...     channel_id="C0920MVPWFN",
+            ...     text="Hello from Definite SDK! 👋"
+            ... )
+            >>> print(f"Message sent! Timestamp: {result['ts']}")
+        """
+        return self.send_message(
+            channel="slack",
+            integration_id=integration_id,
+            to=channel_id,
+            content=text,
+            blocks=blocks,
+            thread_ts=thread_ts,
+            **kwargs
+        )

--- a/examples/test_slack_message.py
+++ b/examples/test_slack_message.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""
+Example script to test Slack messaging functionality
+"""
+import os
+import sys
+from definite_sdk import DefiniteClient
+
+def main():
+    # Get API key from environment
+    api_key = os.getenv("DEF_API_KEY") or os.getenv("DEFINITE_API_KEY")
+    if not api_key:
+        print("Error: Please set DEF_API_KEY or DEFINITE_API_KEY environment variable")
+        sys.exit(1)
+    
+    # Configuration - UPDATE THESE VALUES
+    SLACK_INTEGRATION_ID = os.getenv("SLACK_INTEGRATION_ID", "your_slack_integration_id")
+    CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID", "C0920MVPWFN")
+    
+    # Initialize client
+    client = DefiniteClient(api_key)
+    message_client = client.get_message_client()
+    
+    try:
+        # Example 1: Simple text message using unified interface
+        print("Sending simple text message...")
+        result = message_client.send_message(
+            channel="slack",
+            integration_id=SLACK_INTEGRATION_ID,
+            to=CHANNEL_ID,
+            content="Hello from Definite SDK! 👋 This is a test message."
+        )
+        print(f"✅ Message sent successfully! Timestamp: {result.get('ts', 'N/A')}")
+        
+        # Example 2: Message with Slack blocks
+        print("\nSending message with blocks...")
+        result = message_client.send_message(
+            channel="slack",
+            integration_id=SLACK_INTEGRATION_ID,
+            to=CHANNEL_ID,
+            content="Fallback text",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Definite SDK Test*\nThis message includes _formatted_ text!"
+                    }
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": "*Status:*\n✅ Working"},
+                        {"type": "mrkdwn", "text": "*Version:*\n0.1.8"}
+                    ]
+                }
+            ]
+        )
+        print(f"✅ Block message sent! Timestamp: {result.get('ts', 'N/A')}")
+        
+        # Example 3: Using convenience method
+        print("\nSending via convenience method...")
+        result = message_client.send_slack_message(
+            integration_id=SLACK_INTEGRATION_ID,
+            channel_id=CHANNEL_ID,
+            text="Testing the convenience method! 🚀"
+        )
+        print(f"✅ Convenience method worked! Timestamp: {result.get('ts', 'N/A')}")
+        
+        # Example 4: Reply to thread (if you have a thread_ts)
+        if result.get('ts'):
+            print("\nSending threaded reply...")
+            thread_result = message_client.send_slack_message(
+                integration_id=SLACK_INTEGRATION_ID,
+                channel_id=CHANNEL_ID,
+                text="This is a reply in the thread!",
+                thread_ts=result['ts']
+            )
+            print(f"✅ Thread reply sent! Timestamp: {thread_result.get('ts', 'N/A')}")
+            
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        if hasattr(e, 'response') and hasattr(e.response, 'text'):
+            print(f"Response details: {e.response.text}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,189 @@
+import pytest
+from unittest.mock import Mock, patch
+from definite_sdk import DefiniteClient
+from definite_sdk.message import DefiniteMessageClient
+
+
+@pytest.fixture
+def api_key():
+    return "test_api_key"
+
+
+@pytest.fixture
+def message_client(api_key):
+    return DefiniteMessageClient(api_key, "https://api.definite.app")
+
+
+class TestDefiniteMessageClient:
+    def test_init(self, api_key):
+        client = DefiniteMessageClient(api_key, "https://api.definite.app")
+        assert client._api_key == api_key
+        assert client._message_url == "https://api.definite.app/v3"
+
+    @patch("requests.post")
+    def test_send_slack_message_simple(self, mock_post, message_client):
+        # Mock response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
+        mock_post.return_value = mock_response
+
+        # Send message
+        result = message_client.send_message(
+            channel="slack",
+            integration_id="slack_123",
+            to="C0920MVPWFN",
+            content="Hello from test!"
+        )
+
+        # Verify request
+        mock_post.assert_called_once_with(
+            "https://api.definite.app/v3/slack/message",
+            json={
+                "integration_id": "slack_123",
+                "channel_id": "C0920MVPWFN",
+                "text": "Hello from test!"
+            },
+            headers={"Authorization": "Bearer test_api_key"}
+        )
+
+        assert result == {"ok": True, "ts": "1234567890.123456"}
+
+    @patch("requests.post")
+    def test_send_slack_message_with_blocks(self, mock_post, message_client):
+        # Mock response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
+        mock_post.return_value = mock_response
+
+        # Test blocks
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "*Bold text*"}
+            }
+        ]
+
+        # Send message
+        result = message_client.send_message(
+            channel="slack",
+            integration_id="slack_123",
+            to="C0920MVPWFN",
+            content="Fallback text",
+            blocks=blocks
+        )
+
+        # Verify request
+        mock_post.assert_called_once_with(
+            "https://api.definite.app/v3/slack/message",
+            json={
+                "integration_id": "slack_123",
+                "channel_id": "C0920MVPWFN",
+                "text": "Fallback text",
+                "blocks": blocks
+            },
+            headers={"Authorization": "Bearer test_api_key"}
+        )
+
+    @patch("requests.post")
+    def test_send_slack_message_with_thread(self, mock_post, message_client):
+        # Mock response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
+        mock_post.return_value = mock_response
+
+        # Send threaded message
+        result = message_client.send_message(
+            channel="slack",
+            integration_id="slack_123",
+            to="C0920MVPWFN",
+            content="Reply in thread",
+            thread_ts="1234567890.000000"
+        )
+
+        # Verify request
+        mock_post.assert_called_once_with(
+            "https://api.definite.app/v3/slack/message",
+            json={
+                "integration_id": "slack_123",
+                "channel_id": "C0920MVPWFN",
+                "text": "Reply in thread",
+                "thread_ts": "1234567890.000000"
+            },
+            headers={"Authorization": "Bearer test_api_key"}
+        )
+
+    @patch("requests.post")
+    def test_send_slack_message_convenience_method(self, mock_post, message_client):
+        # Mock response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
+        mock_post.return_value = mock_response
+
+        # Use convenience method
+        result = message_client.send_slack_message(
+            integration_id="slack_123",
+            channel_id="C0920MVPWFN",
+            text="Hello from convenience method!"
+        )
+
+        # Verify request
+        mock_post.assert_called_once_with(
+            "https://api.definite.app/v3/slack/message",
+            json={
+                "integration_id": "slack_123",
+                "channel_id": "C0920MVPWFN",
+                "text": "Hello from convenience method!"
+            },
+            headers={"Authorization": "Bearer test_api_key"}
+        )
+
+        assert result == {"ok": True, "ts": "1234567890.123456"}
+
+    def test_send_message_unsupported_channel(self, message_client):
+        with pytest.raises(ValueError, match="Unsupported channel: email"):
+            message_client.send_message(
+                channel="email",
+                integration_id="email_123",
+                to="test@example.com",
+                content="Hello"
+            )
+
+    @patch("requests.post")
+    def test_send_message_with_additional_kwargs(self, mock_post, message_client):
+        # Mock response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "ts": "1234567890.123456"}
+        mock_post.return_value = mock_response
+
+        # Send message with additional kwargs
+        result = message_client.send_message(
+            channel="slack",
+            integration_id="slack_123",
+            to="C0920MVPWFN",
+            content="Hello",
+            custom_field="custom_value",
+            another_field=123
+        )
+
+        # Verify additional fields are included
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        json_data = call_args[1]["json"]
+        assert json_data["custom_field"] == "custom_value"
+        assert json_data["another_field"] == 123
+
+    def test_client_integration(self, api_key):
+        client = DefiniteClient(api_key)
+        message_client = client.get_message_client()
+        assert isinstance(message_client, DefiniteMessageClient)
+        assert message_client._api_key == api_key
+
+        # Test alias method
+        message_client2 = client.message_client()
+        assert isinstance(message_client2, DefiniteMessageClient)
+        assert message_client2._api_key == api_key


### PR DESCRIPTION
- Add DefiniteMessageClient for sending messages through various channels
- Implement unified send_message() method with channel parameter
- Add convenience send_slack_message() method for Slack-specific usage
- Support Slack blocks, threading, and custom parameters
- Add comprehensive test coverage for messaging functionality
- Update README with messaging examples and documentation
- Create example script for testing Slack messages
