### PR TITLE
chore: bump version to 0.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "definite-sdk"
-version = "0.1.18"
+version = "0.1.19"
 description = "Definite SDK for Python"
 authors = ["Definite <hello@definite.app>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump SDK version from 0.1.18 to 0.1.19 for next PyPI release

## Test plan
- [ ] Merge PR
- [ ] Run `gh workflow run publish.yml` to publish to PyPI
- [ ] Verify package on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)