### PR TITLE
chore: bump version to 0.1.20

### DIFF
--- a/definite_sdk/__init__.py
+++ b/definite_sdk/__init__.py
@@ -12,7 +12,7 @@ from definite_sdk.secret import DefiniteSecretStore
 from definite_sdk.sql import DefiniteSqlClient
 from definite_sdk.store import DefiniteKVStore
 
-__version__ = "0.1.14"
+__version__ = "0.1.20"
 __all__ = [
     "DefiniteClient",
     "DefiniteDriveClient",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "definite-sdk"
-version = "0.1.19"
+version = "0.1.20"
 description = "Definite SDK for Python"
 authors = ["Definite <hello@definite.app>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Version bump to ship:
- [#30](https://github.com/luabase/definite_sdk/pull/30) — `credential_chain` fallback for `attach_ducklake()` on post-Apr-2026 teams
- [#31](https://github.com/luabase/definite_sdk/pull/31) — `DefiniteDriveClient` (`write_file`, `write_temporary_file`), `attach_ducklake()` deprecation with `UnsupportedDuckLakeAttachError`, service-account JSON casing fix

Also syncs `definite_sdk/__init__.py`'s `__version__` to `"0.1.20"` (was stuck at `"0.1.14"` from earlier drift).

## After merge

1. Trigger [Publish to PyPI](https://github.com/luabase/definite_sdk/actions/workflows/publish.yml) manually (`workflow_dispatch` → Run workflow → `main`).
2. Workflow will build, create a `v0.1.20` GitHub release with auto-generated notes, and publish to PyPI via OIDC trusted publishing.
3. Update the SDK pin in e2b templates (`def-python-api/e2b-template/requirements.txt` and `def-python-api/e2b-background-template/requirements.txt`) from `0.1.19` to `0.1.20` and rebuild the templates so new sandboxes pick up the Drive client.

## Test plan

- [ ] CI green
- [ ] Publish workflow runs cleanly after merge
- [ ] `pip install definite-sdk==0.1.20` works; `from definite_sdk import DefiniteDriveClient` succeeds
- [ ] e2b template requirements bumped in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)