### PR TITLE
fix(ci): use default GITHUB_TOKEN for release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,14 @@ jobs:
         run: |
           gh release create "v${{ needs.build.outputs.version }}" --generate-notes
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          # Use the default workflow token — the job already declares
+          # `permissions: contents: write` above, which is enough to create
+          # a release. The previous `secrets.PAT` lost release-creation
+          # permission (HTTP 403 on run 24743806053 for v0.1.20), and we
+          # don't rely on any downstream `on: release` workflow that would
+          # require a PAT to bypass the "tokens don't trigger workflows"
+          # restriction.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-to-pypi:
     name: >-


### PR DESCRIPTION
## Summary

The PyPI publish workflow is currently broken. Run [24743806053](https://github.com/luabase/definite_sdk/actions/runs/24743806053) (triggered after 0.1.20 was merged) failed at the Create-GitHub-Release step:

```
HTTP 403: Resource not accessible by personal access token
https://api.github.com/repos/luabase/definite_sdk/releases
```

The `PAT` secret used by that step no longer has release-creation permission, which cascade-skipped the PyPI publish step.

## Fix

Drop `env: GITHUB_TOKEN: ${{ secrets.PAT }}` on the `gh release create` step — the job already declares `permissions: contents: write`, so the default `${{ secrets.GITHUB_TOKEN }}` has what it needs to create a release.

No downstream `on: release` workflow depends on the trigger coming from a PAT (the GitHub "tokens don't trigger workflows" restriction isn't in play here — we only have Publish + Copilot-review workflows, and neither listens on `release`).

## After merge

1. Re-run the publish workflow from Actions → Publish to PyPI → Run workflow → main. Should now succeed end-to-end: build → GitHub release `v0.1.20` → PyPI publish via OIDC.
2. Optional follow-up: rotate or delete the `PAT` secret since nothing uses it anymore.

## Test plan

- [ ] CI green on this PR (lint/format, if any)
- [ ] After merge, re-run the Publish workflow from main
- [ ] GitHub release `v0.1.20` appears at https://github.com/luabase/definite_sdk/releases
- [ ] `pip install definite-sdk==0.1.20` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)