### PR TITLE
docs: correct + expand SDK usage docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,16 +28,21 @@ poetry run mypy definite_sdk/
 
 This SDK provides Python clients for Definite's cloud storage API (https://api.definite.app). The codebase follows a simple client-factory pattern:
 
-1. **DefiniteClient** (client.py): Main entry point that creates store instances
-2. **Store Implementations**:
+1. **DefiniteClient** (client.py): Main entry point that creates the per-feature clients below
+2. **Clients**:
    - **DefiniteKVStore** (store.py): Dictionary-like persistent key-value storage with version control
    - **DefiniteSecretStore** (secret.py): Direct API for managing application secrets
-   - **DefiniteIntegrationStore** (integration.py): Read-only access to integration configurations
+   - **DefiniteIntegrationStore** (integration.py): Read-only access to integration configurations (credentials live in each integration's `details` dict)
+   - **DefiniteSqlClient** (sql.py): Execute SQL (against integrations or the `LAKE.<schema>.<table>` data lake) and Cube queries
+   - **DefiniteDriveClient** (drive.py): Write files to Definite Drive; pair with the SQL client to load data into the lake
+   - **DefiniteMessageClient** (message.py): Send messages via channels (e.g. Slack)
+   - **DefiniteDLTPipeline** (dlt.py): dlt pipeline wrapper that persists state to a KV store
 
 Key architectural decisions:
 - KV Store uses optimistic locking with version IDs to prevent conflicts
-- KV Store requires explicit `commit()` to persist changes (transactional model)
-- Secret and Integration stores persist changes immediately
+- KV Store requires explicit `commit()` to persist changes (transactional model); keys/values must be strings
+- Secret, Integration, Drive, and SQL operations persist/execute immediately
+- Writing to the data lake: the supported path is Drive + SQL (`get_drive_client().write_temporary_file(...)` then `get_sql_client().execute("CREATE/INSERT/MERGE ... read_parquet('{gcs_path}')")`). `attach_ducklake()` is deprecated and unsupported for workload-identity-only teams.
 - All API calls use Bearer token authentication
 - No caching - each operation makes direct API calls
 
@@ -71,7 +76,3 @@ The workflow will:
 - Publish to PyPI
 
 **Important**: The version in `pyproject.toml` must be incremented before running the publish workflow, otherwise the "Create GitHub Release" step will fail with "Release.tag_name already exists".
-
-## Known Issues
-
-- integration.py incorrectly uses `SECRET_STORE_ENDPOINT` instead of a proper integration endpoint constant

--- a/README.md
+++ b/README.md
@@ -41,50 +41,88 @@ client = DefiniteClient("YOUR_API_KEY")
 - **DuckLake Integration**: Easy attachment of your team's DuckLake to DuckDB connections
 - **DuckDB Support**: Automatic discovery and connection to team's DuckDB integrations
 
+## Which method for which task
+
+| Task | Entry point | Key methods | Persistence |
+|------|-------------|-------------|-------------|
+| Read integration credentials/config | `client.get_integration_store()` | `get_integration(name)`, `get_integration_by_id(id)`, `list_integrations()` | read-only |
+| Store/retrieve your own secrets | `client.get_secret_store()` | `set_secret`, `get_secret`, `list_secrets`, `delete_secret` | immediate |
+| Read from the data lake / databases | `client.get_sql_client()` | `execute(sql)`, `execute_cube_query(...)` | n/a |
+| Write to the data lake (recommended) | `client.get_drive_client()` + `client.get_sql_client()` | `write_temporary_file(...)` then `execute("CREATE/INSERT/MERGE ...")` | immediate |
+| Write to the data lake (legacy) | `client.attach_ducklake()` | returns SQL to attach DuckLake to a local DuckDB — **deprecated** | immediate |
+| Persist key-value state | `client.get_kv_store(name)` | `store[key] = value`, then `store.commit()` | **explicit `commit()`** |
+| Send messages (Slack, …) | `client.get_message_client()` | `send_message(...)`, `send_slack_message(...)` | immediate |
+
+The data lake is a **DuckLake** warehouse addressed in SQL as `LAKE.<schema>.<table>`.
+
 ## Basic Usage
 
 ### 🗄️ Key-Value Store
 
 Store and retrieve key-value pairs that can be accessed by custom Python scripts hosted on Definite.
 
+The store behaves like a Python dict in memory, but **nothing is saved until you call `commit()`**. Keys and values must both be strings — JSON-encode anything more complex.
+
 ```python
+import json
+
 # Initialize or retrieve an existing key-value store
 store = client.get_kv_store('test_store')
 # Or use the alias method
 store = client.kv_store('test_store')
 
-# Add or update key-value pairs
+# Add or update key-value pairs (values must be strings)
 store['replication_key'] = 'created_at'
 store['replication_state'] = '2024-05-20'
 store["key1"] = "value1"
-store["key2"] = {"nested": "data"}
+store["key2"] = json.dumps({"nested": "data"})  # JSON-encode non-string values
 
-# Commit changes
+# Commit changes (REQUIRED — without this, nothing is persisted)
 store.commit()
 
 # Retrieve values
-print(store['replication_key'])  # 'created_at'
-value = store["key1"]
+print(store['replication_key'])         # 'created_at'
+value = store["key1"]                    # "value1"
+nested = json.loads(store["key2"])       # {"nested": "data"}
+missing = store.get("absent", "default") # dict-style get with default
 ```
+
+**Versioning / conflict handling:** the store loads a `version_id` when you open it and sends it on `commit()`. If someone else committed in the meantime, your `commit()` raises rather than silently overwriting their changes (optimistic locking). Re-open the store and re-apply your changes to retry. Call `store.delete()` to permanently remove the whole store.
 
 ### 🗃️ SQL Query Execution
 
-Execute SQL queries against your connected database integrations.
+Execute SQL queries against your connected database integrations, or against the data lake (`LAKE.<schema>.<table>`).
 
 ```python
 # Initialize the SQL client
 sql_client = client.get_sql_client()
 
-# Execute a SQL query
-result = sql_client.execute("SELECT * FROM users LIMIT 10")
-print(result)
+# Read from a data lake table
+result = sql_client.execute("SELECT * FROM LAKE.MY_SCHEMA.events LIMIT 10")
 
-# Execute a SQL query with a specific integration
+# Execute a SQL query against a specific integration
+# (integration_id is the ID from the integration's page URL; omit it to use the default)
 result = sql_client.execute(
     "SELECT COUNT(*) FROM orders WHERE status = 'completed'",
     integration_id="my_database_integration"
 )
-print(result)
+```
+
+`execute()` returns a parsed JSON dict shaped like:
+
+```python
+{
+    "success": True,
+    "columns": ["id", "name"],
+    "data": [
+        {"id": 1, "name": "John"},
+        {"id": 2, "name": "Jane"},
+    ],
+}
+
+# Access rows:
+for row in result["data"]:
+    print(row["name"])
 ```
 
 ### 📊 Cube Query Execution
@@ -111,6 +149,60 @@ result = sql_client.execute_cube_query(
 print(result)
 ```
 
+### 🏞️ Writing to the Data Lake
+
+The recommended way to load data into the lake is **Drive + SQL**: upload a file (parquet/csv) to Definite Drive, then run a SQL statement that reads it into a `LAKE.<schema>.<table>` table. This works for all teams (including workload-identity-only teams provisioned after April 2026).
+
+```python
+import io
+import pandas as pd
+
+drive = client.get_drive_client()   # alias: client.drive_client()
+sql_client = client.get_sql_client()
+
+# 1. Turn a DataFrame into parquet bytes
+df = pd.DataFrame([{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}])
+buf = io.BytesIO()
+df.to_parquet(buf)
+
+# 2. Upload to a temporary, auto-expiring location in Drive
+result = drive.write_temporary_file(buf.getvalue(), name="users.parquet", ttl_days=7)
+# result.gcs_path -> "gs://.../users.parquet", usable directly in SQL
+
+# 3a. CREATE (or replace) a lake table from the uploaded file
+sql_client.execute(
+    f"CREATE OR REPLACE TABLE LAKE.MY_SCHEMA.users AS "
+    f"SELECT * FROM read_parquet('{result.gcs_path}')"
+)
+
+# 3b. INSERT (append) into an existing table
+sql_client.execute(
+    f"INSERT INTO LAKE.MY_SCHEMA.users "
+    f"SELECT * FROM read_parquet('{result.gcs_path}')"
+)
+
+# 3c. MERGE / upsert on a key
+sql_client.execute(f"""
+    MERGE INTO LAKE.MY_SCHEMA.users AS t
+    USING (SELECT * FROM read_parquet('{result.gcs_path}')) AS s
+    ON t.id = s.id
+    WHEN MATCHED THEN UPDATE SET *
+    WHEN NOT MATCHED THEN INSERT *
+""")
+```
+
+**Drive write methods** (`client.get_drive_client()`):
+
+- `write_temporary_file(data, name=..., ttl_days=1..30)` — server picks a path under `_tmp/<date>/<uuid>/<name>`, auto-deleted after the TTL. Use it to stage data for a one-time ingest.
+- `write_file(data, path="folder/file.parquet")` — persistent file at an explicit path, kept until you delete it.
+
+Both accept `bytes`, `str`, a filesystem path, or a binary file-like object, and return a `DriveWriteResult` with:
+
+- `gcs_path` — full `gs://` URI; use this in SQL (`read_parquet(...)`, `read_csv(...)`, …).
+- `drive_path` — the path a pipeline sandbox sees (`/home/user/drive/...`).
+- `path` — the drive-relative path (e.g. `ingest/events.parquet`).
+- `expires_at` — ISO 8601 deletion time (temporary writes only).
+
 ### 🔒 Secret Store
 
 Securely store and retrieve secrets for your integrations.
@@ -133,7 +225,7 @@ secrets = list(secret_store.list_secrets())
 
 ### 🔗 Integration Management
 
-Manage your data integrations and connections.
+Read-only access to your integrations. Credentials and config live in the integration's `details` dict — this is how you obtain an integration's API key, host, tokens, etc.
 
 ```python
 # Initialize the integration store
@@ -141,11 +233,29 @@ integration_store = client.get_integration_store()
 # Or use the alias method
 integration_store = client.integration_store()
 
-# List all integrations
-integrations = list(integration_store.list_integrations())
+# List all integrations (optionally filter by type or category)
+integrations = integration_store.list_integrations()                       # all
+integrations = integration_store.list_integrations(integration_type="slack")
+# Each item in list_integrations() is {"id": <id>, **details} — id + flattened details.
 
-# Get a specific integration
-integration = integration_store.get_integration("my_integration")
+# Get a specific integration's details (by name or by id)
+details = integration_store.get_integration("my_integration")        # returns the details dict
+details = integration_store.get_integration_by_id("integration_uuid")
+
+# Read a credential / config value out of the details dict
+api_key = details.get("api_key")
+host = details.get("host")
+```
+
+> Note the return-shape difference: `list_integrations()` injects the `id` and flattens the
+> details into each record, while `get_integration()` / `get_integration_by_id()` return only
+> the `details` dict (no `id`). Both raise if nothing matches.
+
+You can also inspect an integration's sync (DAG) runs:
+
+```python
+runs = integration_store.get_syncs("integration_id", limit=50, status="FAILED")
+latest = integration_store.get_latest_sync("integration_id")
 ```
 
 ### 💬 Messaging
@@ -211,9 +321,16 @@ pipeline.run(orders())
 last_cursor = pipeline.get_state("orders")
 ```
 
-### DuckLake Integration
+### DuckLake Integration (legacy / deprecated)
 
-Attach your team's DuckLake to a DuckDB connection for seamless data access:
+> ⚠️ **Deprecated.** `attach_ducklake()` only works for legacy teams that have HMAC keys or a
+> service-account JSON on their DuckLake integration. Teams provisioned after **April 2026** use
+> workload-identity-only auth and will raise `UnsupportedDuckLakeAttachError`, since those
+> credentials cannot be replicated on a customer laptop. Calling it also emits a
+> `DeprecationWarning`. **Use the [Writing to the Data Lake](#-writing-to-the-data-lake)
+> (Drive + SQL) workflow instead** — it works for all teams.
+
+Attach your team's DuckLake to a local DuckDB connection for direct data access:
 
 ```python
 import duckdb
@@ -222,7 +339,7 @@ from definite_sdk import DefiniteClient
 # Initialize the client
 client = DefiniteClient("YOUR_API_KEY")
 
-# Connect to DuckDB and attach DuckLake
+# Connect to DuckDB and attach DuckLake (raises UnsupportedDuckLakeAttachError on newer teams)
 conn = duckdb.connect()
 conn.execute(client.attach_ducklake())
 

--- a/example_usage.py
+++ b/example_usage.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 """
-Example script demonstrating the usage of Definite SDK SQL functionality.
+Example script demonstrating common Definite SDK workflows.
 
 This script shows how to:
 1. Initialize the Definite client
-2. Execute SQL queries against database integrations
+2. Execute SQL queries against database integrations and the data lake
 3. Execute Cube queries for analytics
-4. Handle errors appropriately
+4. Read integration credentials/config from the integration store
+5. Use the key-value store (including the required commit())
+6. Handle errors appropriately
+
+For writing data into the lake (Drive + SQL insert/merge), see
+examples/lake_write_example.py.
 """
 
+import json
 import os
 import sys
 from definite_sdk import DefiniteClient
@@ -81,24 +87,49 @@ def main():
             "💡 Make sure to replace 'your_cube_integration_id' with your actual Cube integration ID"
         )
 
-    # Example 4: Demonstrating other SDK features
-    print("\n4. Other SDK features:")
+    # Example 4: Reading from a data lake table
+    print("\n4. Reading from the data lake (LAKE.<schema>.<table>):")
+    try:
+        result = sql_client.execute("SELECT * FROM LAKE.MY_SCHEMA.events LIMIT 5")
+        # execute() returns {"success": bool, "columns": [...], "data": [{col: val}, ...]}
+        print(f"   ✅ Columns: {result.get('columns')}")
+        for row in result.get("data", []):
+            print(f"      {row}")
+    except Exception as e:
+        print(f"   ❌ Lake read failed: {e}")
+        print("   💡 Replace MY_SCHEMA.events with a table that exists in your lake")
 
-    # Key-value store
+    # Example 5: Demonstrating other SDK features
+    print("\n5. Other SDK features:")
+
+    # Key-value store — values must be strings, and commit() is REQUIRED to persist.
     print("\n   📦 Key-Value Store:")
     try:
         store = client.get_kv_store("example_store")
         store["example_key"] = "example_value"
+        store["nested_key"] = json.dumps({"nested": "data"})  # JSON-encode non-strings
+        store.commit()  # without this, nothing is persisted
+
+        # Re-open to confirm the values were saved server-side
+        store = client.get_kv_store("example_store")
         print(f"   ✅ Stored value: {store['example_key']}")
+        print(f"   ✅ Nested value: {json.loads(store['nested_key'])}")
     except Exception as e:
         print(f"   ❌ KV store operation failed: {e}")
 
-    # List integrations
+    # Integrations — credentials/config live in each integration's `details` dict
     print("\n   🔗 Integration Management:")
     try:
         integration_store = client.get_integration_store()
-        integrations = list(integration_store.list_integrations())
+        integrations = integration_store.list_integrations()
         print(f"   ✅ Found {len(integrations)} integrations")
+        if integrations:
+            # list_integrations() returns {"id": ..., **details} per integration
+            first = integrations[0]
+            print(f"   ✅ First integration id: {first.get('id')}")
+            # To read credentials, fetch the details dict by name or id:
+            # details = integration_store.get_integration("my_integration")
+            # api_key = details.get("api_key")
     except Exception as e:
         print(f"   ❌ Integration listing failed: {e}")
 

--- a/examples/ducklake_example.py
+++ b/examples/ducklake_example.py
@@ -1,6 +1,12 @@
 """
-Example demonstrating how to use the attach_ducklake() method 
+Example demonstrating how to use the attach_ducklake() method
 to connect to your team's DuckLake from DuckDB.
+
+DEPRECATED: attach_ducklake() only works for legacy teams with HMAC keys or a
+service-account JSON on their DuckLake integration. Teams provisioned after
+April 2026 use workload-identity-only auth and will raise
+UnsupportedDuckLakeAttachError. For the supported way to write to the lake, see
+examples/lake_write_example.py (Drive + SQL).
 """
 
 import os

--- a/examples/lake_write_example.py
+++ b/examples/lake_write_example.py
@@ -1,0 +1,100 @@
+"""
+Example demonstrating the recommended way to write data into the Definite data
+lake: upload a file to Definite Drive, then run SQL that reads it into a
+``LAKE.<schema>.<table>`` table.
+
+This Drive + SQL workflow works for all teams, including workload-identity-only
+teams provisioned after April 2026 (for which the legacy ``attach_ducklake()``
+helper raises ``UnsupportedDuckLakeAttachError``). See examples/ducklake_example.py
+for the deprecated local-DuckDB approach.
+"""
+
+import io
+import os
+
+import pandas as pd
+
+from definite_sdk import DefiniteClient
+
+SCHEMA = "example"
+TABLE = f"LAKE.{SCHEMA}.users"
+
+
+def main():
+    """Create, append to, and upsert into a data lake table via Drive + SQL."""
+
+    api_key = os.environ.get("DEFINITE_API_KEY")
+    if not api_key:
+        print("Please set DEFINITE_API_KEY environment variable")
+        return
+
+    client = DefiniteClient(api_key)
+    drive = client.get_drive_client()
+    sql = client.get_sql_client()
+
+    def upload(df: pd.DataFrame, name: str) -> str:
+        """Serialize a DataFrame to parquet and upload it to Drive; return its gcs_path."""
+        buf = io.BytesIO()
+        df.to_parquet(buf)
+        result = drive.write_temporary_file(buf.getvalue(), name=name, ttl_days=1)
+        print(f"   uploaded {name} -> {result.gcs_path}")
+        return result.gcs_path
+
+    try:
+        # 1. CREATE (or replace) the table from an uploaded parquet file
+        print("Creating table via CREATE OR REPLACE ...")
+        initial = pd.DataFrame(
+            [
+                {"id": 1, "name": "alice", "department": "engineering"},
+                {"id": 2, "name": "bob", "department": "product"},
+            ]
+        )
+        gcs_path = upload(initial, "users_initial.parquet")
+        sql.execute(
+            f"CREATE OR REPLACE TABLE {TABLE} AS "
+            f"SELECT * FROM read_parquet('{gcs_path}')"
+        )
+        print("✅ Table created")
+
+        # 2. INSERT (append) more rows
+        print("\nAppending rows via INSERT INTO ...")
+        more = pd.DataFrame([{"id": 3, "name": "carol", "department": "design"}])
+        gcs_path = upload(more, "users_append.parquet")
+        sql.execute(
+            f"INSERT INTO {TABLE} SELECT * FROM read_parquet('{gcs_path}')"
+        )
+        print("✅ Rows appended")
+
+        # 3. MERGE / upsert on the `id` key (update existing, insert new)
+        print("\nUpserting rows via MERGE INTO ...")
+        changes = pd.DataFrame(
+            [
+                {"id": 2, "name": "bob", "department": "growth"},  # update
+                {"id": 4, "name": "dave", "department": "sales"},  # insert
+            ]
+        )
+        gcs_path = upload(changes, "users_merge.parquet")
+        sql.execute(
+            f"""
+            MERGE INTO {TABLE} AS t
+            USING (SELECT * FROM read_parquet('{gcs_path}')) AS s
+            ON t.id = s.id
+            WHEN MATCHED THEN UPDATE SET *
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        )
+        print("✅ Rows upserted")
+
+        # 4. Read the result back
+        print("\nReading the table back:")
+        result = sql.execute(f"SELECT * FROM {TABLE} ORDER BY id")
+        for row in result.get("data", []):
+            print(f"   {row}")
+
+    except Exception as e:
+        print(f"❌ Error: {e}")
+
+
+if __name__ == "__main__":
+    print("=== Data Lake Write Example (Drive + SQL) ===")
+    main()


### PR DESCRIPTION
## Context

A walkthrough of the SDK (obtaining integration credentials, writing to the data lake with insert/merge, reading from the lake, and the KV store) surfaced documentation that was **wrong or missing** in `README.md`, `example_usage.py`, and `CLAUDE.md`. Several items didn't just omit detail — they taught the wrong thing, which is especially damaging for an LLM that copies examples verbatim.

## What was wrong

- `README.md` documented only the **deprecated** `attach_ducklake()` lake-write path, with no deprecation note, and never mentioned the recommended Drive + SQL workflow.
- `README.md` showed a KV write of a dict, but `store.py` asserts string-only values → that example raises `AssertionError`.
- `example_usage.py` wrote to a KV store but never called `commit()`, so it persisted nothing while appearing to succeed.
- `CLAUDE.md` "Known Issues" warned about a `SECRET_STORE_ENDPOINT` bug already fixed in `integration.py`, and its architecture section listed only 3 of the SDK's client classes.

## Changes

- **README**: add a top "which method for which task" routing table; fix the KV example (JSON-encode non-strings) and document the required `commit()` + optimistic locking; add a **"Writing to the Data Lake"** section using the supported Drive + SQL workflow with `CREATE`/`INSERT`/`MERGE` examples; demote `attach_ducklake()` to a deprecated subsection; document `execute()`'s return shape and the `LAKE.<schema>.<table>` namespace; add credential-extraction + return-shape notes to the integration section.
- **example_usage.py**: broaden beyond SQL to all four tasks; fix the missing `commit()`; add lake-read and credential snippets.
- **examples/lake_write_example.py** (new): end-to-end Drive + SQL write (CREATE → INSERT → MERGE → read back).
- **examples/ducklake_example.py**: deprecation banner pointing to the Drive + SQL example.
- **CLAUDE.md**: list all current client classes; document Drive + SQL as the supported lake-write path; remove the stale `SECRET_STORE_ENDPOINT` issue.

## Verification

- `py_compile` + AST parse pass for all three example files.
- SDK imports and every referenced symbol (`get_drive_client`, `get_sql_client`, `DriveWriteResult`, `UnsupportedDuckLakeAttachError`) resolve.
- Docs/examples-only change — no source code modified. (`pytest` is not installed in the available local envs, so the suite was not run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)